### PR TITLE
Fix slight syntax errors in README.md code

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ paint "[fg=#FF0000 underline]DANGER[fg=reset underline=reset]"
 
 # 256 color support
 paint "                        [fg=255 bg=24]┌────────────────────┐[reset]"
-paint "                        [fg=255 bg=24]│       Submit       │[reset]"
+paint "                        [fg=255 bg=24]│     Submit         │[reset]"
 paint "                        [fg=255 bg=24]└────────────────────┘[reset]"
 
 ```


### PR DESCRIPTION
Some code snippets had errroneous nim code in there. Fixed what I saw.